### PR TITLE
Major modifications:  1. Switch glob libraries to one that (seemingly…

### DIFF
--- a/pkg/sigma/v2/ident.go
+++ b/pkg/sigma/v2/ident.go
@@ -92,7 +92,7 @@ func (k Keyword) Match(msg Event) (bool, bool) {
 func NewKeyword(expr interface{}) (*Keyword, error) {
 	switch val := expr.(type) {
 	case []string:
-		return newStringKeyword(TextPatternContains, false, val...)
+		return newStringKeyword(TextPatternKeyword, false, val...)
 	case []interface{}:
 		k, ok := isSameKind(val)
 		if !ok {
@@ -105,7 +105,7 @@ func NewKeyword(expr interface{}) (*Keyword, error) {
 		}
 		switch v := k; {
 		case v == reflect.String:
-			return newStringKeyword(TextPatternContains, false, castIfaceToString(val)...)
+			return newStringKeyword(TextPatternKeyword, false, castIfaceToString(val)...)
 		default:
 			return nil, ErrInvalidKind{
 				Kind:     v,

--- a/pkg/sigma/v2/ident_test.go
+++ b/pkg/sigma/v2/ident_test.go
@@ -97,7 +97,7 @@ var identSelection1 = `
 detection:
   condition: selection
   selection:
-    winlog.event_data.ScriptBlockText:
+    winlog.event_data.ScriptBlockText|contains:
     - ' -FromBase64String'
     - '::FromBase64String'
 `

--- a/pkg/sigma/v2/parser_test.go
+++ b/pkg/sigma/v2/parser_test.go
@@ -391,6 +391,45 @@ var detection12_negative = `
 }
 `
 
+//this test is a bit tricky; it all hinges on the bits*admin rule where the middle glob
+//is escaped, making it an asterisk instead of a glob
+var detection13 = `
+detection:
+  condition: "all of them"
+  selection_images:
+    Image:
+    - '*\schtasks.exe'
+    - '*\nslookup.exe'
+    - '*\certutil.exe'
+    - '*\bits\*admin.exe'
+    - '*\mshta.exe'
+  selection_parent_images:
+    ParentImage:
+    - '*\mshta.exe'
+    - '*\powershell.exe'
+    - '*\cmd.exe'
+    - '*\rundll32.exe'
+    - '*\cscript.exe'
+    - '*\wscript.exe'
+    - '*\wmiprvse.exe'
+`
+
+var detection13_positive = `
+{
+	"Image":       "C:\\test\\bits*admin.exe",
+	"ParentImage": "C:\\test\\wmiprvse.exe",
+	"Image":       "C:\\test\\bits*admin.exe",
+	"ParentImage": "C:\\test\\wmiprvse.exe"
+}
+`
+
+var detection13_negative = `
+{
+	"Image":       "C:\\test\\bitsadmin.exe",
+	"ParentImage": "C:\\test\\mshta\\lll.exe"
+}
+`
+
 type parseTestCase struct {
 	Rule     string
 	Pos, Neg []string
@@ -456,6 +495,11 @@ var parseTestCases = []parseTestCase{
 		Rule: detection12,
 		Pos:  []string{detection12_positive},
 		Neg:  []string{detection12_negative},
+	},
+	{
+		Rule: detection13,
+		Pos:  []string{detection13_positive},
+		Neg:  []string{detection13_negative},
 	},
 }
 

--- a/pkg/sigma/v2/tree.go
+++ b/pkg/sigma/v2/tree.go
@@ -204,6 +204,7 @@ func extractAndBuildBranches(d Detection, g string) ([]Branch, error) {
 func extractWildcardIdents(d Detection, g string) ([]interface{}, error) {
 	rules := make([]interface{}, 0)
 	for k, v := range d {
+		//I don't think this needs to use the other glob library?
 		if glob.Glob(g, k) {
 			rules = append(rules, v)
 		}


### PR DESCRIPTION
…) respects escaping of     characters.  2. Changed default matching for 'selection' to be a case-insensitive     strict match.  Generally, rules with selection will use globs or     modifiers when they mean to have wildcard handling  3. Added new  type to modifiers; this is a special     modifier type that is ONLY used by 'Keywords' rules.  This flag     basically will check for non-spec regex first and if the keyword is     not that, it will treat it as a 'contains' style glob (keyword     surrounded by *).  This is useful where keywords tend to bounce     against verbose log messages that can be messy to try to match     directly... (technically, I think this is out of spec though).